### PR TITLE
Change SCRIPT_DIR= assignments to use 'realpath' -- avoids funky prob…

### DIFF
--- a/build/bin/build
+++ b/build/bin/build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # Check dependencies are met.

--- a/build/bin/build_addpkgs
+++ b/build/bin/build_addpkgs
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 X_SRCDIR=${CUR_DIR}

--- a/build/bin/build_airstation
+++ b/build/bin/build_airstation
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_cleanobj
+++ b/build/bin/build_cleanobj
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 CFGNAME=$1

--- a/build/bin/build_cleanroot
+++ b/build/bin/build_cleanroot
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 CFGNAME=$1

--- a/build/bin/build_dlink
+++ b/build/bin/build_dlink
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_fetchpkgs
+++ b/build/bin/build_fetchpkgs
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 X_SRCDIR=${CUR_DIR}

--- a/build/bin/build_freebsd
+++ b/build/bin/build_freebsd
@@ -23,7 +23,7 @@
 # after Warner's "tbemd" build framework changes.
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 CFGNAME=$1

--- a/build/bin/build_fsimage
+++ b/build/bin/build_fsimage
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_fullfsimage
+++ b/build/bin/build_fullfsimage
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_fullroot
+++ b/build/bin/build_fullroot
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 X_SRCDIR=${CUR_DIR}

--- a/build/bin/build_makepkgs
+++ b/build/bin/build_makepkgs
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 X_SRCDIR=${CUR_DIR}

--- a/build/bin/build_mfsroot
+++ b/build/bin/build_mfsroot
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 X_SRCDIR=${CUR_DIR}

--- a/build/bin/build_netboot
+++ b/build/bin/build_netboot
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_ralink
+++ b/build/bin/build_ralink
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_tinymfsroot
+++ b/build/bin/build_tinymfsroot
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_tplink
+++ b/build/bin/build_tplink
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_trx
+++ b/build/bin/build_trx
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_ubnt
+++ b/build/bin/build_ubnt
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/build/bin/build_uboot
+++ b/build/bin/build_uboot
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # suck in the per-device options

--- a/port-build/scripts/cross_build
+++ b/port-build/scripts/cross_build
@@ -3,7 +3,7 @@
 # set -e
 
 SCRIPT_NAME="`basename $0`"
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 CUR_DIR="`pwd`"
 
 # need a root directory!

--- a/scripts/build_modules/build_modules
+++ b/scripts/build_modules/build_modules
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SCRIPT_DIR="`dirname $0`"
+SCRIPT_DIR="$(dirname `realpath $0`)"
 
 MODULES_LIST=${MODULES_LIST:="ath ath_pci wlan wlan_acl wlan_amrr wlan_ccmp wlan_rssadapt wlan_tkip wlan_wep wlan_xauth bwi bwn mwl wi wpi iwn iwi iwnfw"}
 


### PR DESCRIPTION
…lems with relative invocation

Should be reproducible with the following setup:

/wifi-build
- src/
- freebsd-wifi-build/
- ...

Invoke ../freebsd-wifi-build/build/bin/build carambola2 makepkgs from /wifi-build/src, should fail to find patches for dnsmasq/dropbear and fail to create the packages.